### PR TITLE
add compatibility for angular 13 ...

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-angular/encoder.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-angular/encoder.mustache
@@ -12,10 +12,12 @@
 * See: https://github.com/angular/angular/issues/11058#issuecomment-247367318
 */
 export class CustomHttpUrlEncodingCodec extends HttpUrlEncodingCodec {
+    // @ts-ignore
     encodeKey(k: string): string {
         k = super.encodeKey(k);
         return k.replace(/\+/gi, '%2B');
     }
+    // @ts-ignore
     encodeValue(v: string): string {
         v = super.encodeValue(v);
         return v.replace(/\+/gi, '%2B');


### PR DESCRIPTION
by ignoring noImplicitOverride directive, which is set to true in angular 13. We use ignore instead of adding override to keep compatibilty with older typescript versions (<4.3)

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming language.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

